### PR TITLE
Fixes connected Waste and Distribution pipes on Talistation

### DIFF
--- a/_maps/map_files/TaliStation/TaliStation.dmm
+++ b/_maps/map_files/TaliStation/TaliStation.dmm
@@ -110,9 +110,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -762,10 +759,11 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/solars/starboard)
 "ayn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "ayH" = (
 /obj/structure/bookcase/random,
@@ -1144,8 +1142,8 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/bar)
 "aMD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -2280,9 +2278,6 @@
 /area/engine/engineering)
 "bvJ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -5359,12 +5354,6 @@
 /area/hallway/primary/aft)
 "dft" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -9917,8 +9906,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "fNv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -11547,6 +11536,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"gKY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "gLb" = (
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
@@ -19022,9 +19018,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "kUa" = (
@@ -26203,10 +26196,6 @@
 /area/library)
 "oXd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
@@ -29106,6 +29095,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "qKJ" = (
@@ -29510,8 +29500,6 @@
 "rbi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -31777,6 +31765,7 @@
 "skg" = (
 /obj/structure/closet/radiation,
 /obj/machinery/camera/autoname,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "skB" = (
@@ -33009,6 +32998,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/commons/cryopods)
+"sTB" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer5,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "sTO" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -39466,11 +39466,11 @@
 /turf/open/floor/plasteel/white/side,
 /area/hallway/secondary/entry)
 "wyX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "wzU" = (
@@ -39919,6 +39919,9 @@
 /area/engine/atmos)
 "wNo" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "wNs" = (
@@ -79344,7 +79347,7 @@ cNT
 lDM
 fPx
 bvJ
-ayn
+ngL
 vzM
 jDC
 xuG
@@ -79597,7 +79600,7 @@ mWd
 yln
 sye
 aHE
-aHE
+ayn
 aMD
 skg
 wyX
@@ -79854,7 +79857,7 @@ iwG
 eZw
 mnv
 uZH
-uZH
+sTB
 dft
 rbi
 oXd
@@ -80111,7 +80114,7 @@ yfq
 yln
 sye
 aHE
-aHE
+gKY
 fNv
 qKF
 wNo


### PR DESCRIPTION
Fixes the Waste and Distribution pipes being connected together by a manifold that was placed ontop of both of them, and incinerator input on Talistation.
This PR closes issue #784 
This is my first ever PR. So i hope i didnt majorly destroy anything by accident.

>Before the edit
![Before le edit](https://user-images.githubusercontent.com/82319946/190947375-7eabf0bc-ce6f-4750-8767-12e05f9bf2b3.png)
>After the edit
![After le edit](https://user-images.githubusercontent.com/82319946/190947380-3dd645a8-d5cf-4a65-8090-03aba38031e5.png)
