### PR TITLE
fixes the compact mining hardsuit sprites

### DIFF
--- a/ModularBungalow/clothing/hardsuits.dm
+++ b/ModularBungalow/clothing/hardsuits.dm
@@ -76,6 +76,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/mining/compact/Initialize()
 	. = ..()
+	UnregisterSignal(src, COMSIG_ARMOR_PLATED, .proc/upgrade_icon)
 
 /obj/item/clothing/head/helmet/space/hardsuit/mining/compact
 	name = "compact mining hardsuit helmet"
@@ -87,6 +88,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/mining/compact/Initialize()
 	. = ..()
+	UnregisterSignal(src, COMSIG_ARMOR_PLATED, .proc/upgrade_icon)
 
 //BNI hardsuit
 /obj/item/clothing/suit/space/hardsuit/ert/bni
@@ -119,6 +121,7 @@
 	icon_state = "hardsuit0-atmospherics"
 	icon = 'ModularBungalow/clothing/icons/helmet.dmi'
 	worn_icon = 'ModularBungalow/clothing/worn/helmetw.dmi'
+	hardsuit_type = "atmospherics"
 
 /obj/item/clothing/suit/space/hardsuit/engine/atmos/old
 	name = "atmospherics hardsuit"

--- a/ModularBungalow/clothing/hardsuits.dm
+++ b/ModularBungalow/clothing/hardsuits.dm
@@ -64,7 +64,6 @@
 	slowdown = -0.5
 
 
-//ERT hardsuit
 /obj/item/clothing/suit/space/hardsuit/mining/compact
 	name = "compact mining hardsuit"
 	worn_icon = 'ModularBungalow/clothing/worn/coatw.dmi'
@@ -75,13 +74,19 @@
 	armor = list(MELEE = 25, BULLET = 5, LASER = 10, ENERGY = 15, BOMB = 50, BIO = 100, RAD = 40, FIRE = 30, ACID = 75, WOUND = 5)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining/compact
 
+/obj/item/clothing/suit/space/hardsuit/mining/compact/Initialize()
+	. = ..()
+
 /obj/item/clothing/head/helmet/space/hardsuit/mining/compact
 	name = "compact mining hardsuit helmet"
 	worn_icon = 'ModularBungalow/clothing/worn/helmetw.dmi'
 	icon = 'ModularBungalow/clothing/icons/helmet.dmi'
 	icon_state = "hardsuit0-mineclassic"
+	hardsuit_type = "mineclassic"
 	armor = list(MELEE = 25, BULLET = 5, LASER = 10, ENERGY = 15, BOMB = 50, BIO = 100, RAD = 40, FIRE = 30, ACID = 75, WOUND = 5)
 
+/obj/item/clothing/head/helmet/space/hardsuit/mining/compact/Initialize()
+	. = ..()
 
 //BNI hardsuit
 /obj/item/clothing/suit/space/hardsuit/ert/bni

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -222,6 +222,7 @@
 	inhand_icon_state = "pwig"
 	worn_icon_state = "wig"
 	flags_inv = HIDEHAIR | HIDEHEADGEAR
+	dynamic_hair_suffix = ""
 	color = "#000"
 	var/hairstyle = "Very Long Hair"
 	var/adjustablecolor = TRUE //can color be changed manually?

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -180,11 +180,6 @@
 	icon_state = "petcollar"
 	var/tagname = null
 
-/obj/item/clothing/neck/petcollar/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
-	if(ishuman(M))
-		return FALSE
-	return ..()
-
 /obj/item/clothing/neck/petcollar/attack_self(mob/user)
 	tagname = sanitize_name(stripped_input(user, "Would you like to change the name on the tag?", "Name your new pet", "Spot", MAX_NAME_LEN))
 	name = "[initial(name)] - [tagname]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the helmet light sprite wasn't set and the hardsuit doesn't have goliath plated sprites, both of which would turn the suit permanently invisible  
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the compact mining hardsuit nolonger turns invisible if you turn on the helmet light or add goliath plates
fix: wearing a wig now hides the hair under it 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
