### PR TITLE
fixes cap's melter gun beacon choice

### DIFF
--- a/ModularBungalow/bungalow_beacon.dm
+++ b/ModularBungalow/bungalow_beacon.dm
@@ -84,7 +84,7 @@
 	name = "Melter Rifle"
 	desc = "For the captain that hates others."
 
-/obj/item/storage/box/captain/gun/shotgun/PopulateContents()
+/obj/item/storage/box/captain/gun/melter/PopulateContents()
 	new /obj/item/gun/energy/laser/hellgun(src)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes https://github.com/Quasar-13/Quasar-13/issues/786
fixes https://github.com/Quasar-13/Quasar-13/issues/781
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: cap's gun beacon now actually has the melter gun rifle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
